### PR TITLE
don't subtract max timestamp in TTL calculation

### DIFF
--- a/src/lib/redis-store.ts
+++ b/src/lib/redis-store.ts
@@ -17,10 +17,7 @@ class RedisStore implements Store {
   ): Promise<void> {
     return new Promise<void>((res, rej): void => {
       const expiry = windowMs
-        ? [
-            'EX',
-            Math.ceil((Date.now() + windowMs - Math.max(...timestamps)) / 1000),
-          ]
+        ? ['EX', Math.ceil((Date.now() + windowMs) / 1000)]
         : [];
       this.store.set(
         [


### PR DESCRIPTION
Addresses the issue outlined in this issue log filed in the original repo: https://github.com/teamplanes/graphql-rate-limit/issues/188